### PR TITLE
[FIX] prevent reconciliation if transaction_ref and ref in bank state…

### DIFF
--- a/l10n_ch_account_reconcile_esr/models/account_bank_statement_line.py
+++ b/l10n_ch_account_reconcile_esr/models/account_bank_statement_line.py
@@ -40,7 +40,8 @@ class AccountBankStatementLine(models.Model):
         # Try to get ESR match
         if self.name:
             sql_query = self._get_common_sql_query_ignore_partner() + \
-                " AND aml.transaction_ref = %(ref)s ORDER BY \
+                " AND aml.transaction_ref = %(ref)s" \
+                " AND aml.transaction_ref is not null ORDER BY \
                 date_maturity asc, aml.id asc"
             self.env.cr.execute(sql_query, params)
             match_recs = self.env.cr.dictfetchall()


### PR DESCRIPTION
Purpose:
If ref in statement line and transaction_ref is null we will have a reconcile match, it's wrong

Dev:
Check that we have a transaction_ref set in the account move line